### PR TITLE
カスタムフィールドで分岐

### DIFF
--- a/page-creator.php
+++ b/page-creator.php
@@ -13,24 +13,24 @@ Template Name: creator
             所属クリエイター
           </span>
         </div>
-        <?php $posts = get_posts('numberposts=10&category=4'); global $post; ?>
-        <?php if($posts): foreach($posts as $post): setup_postdata($post); ?>
         <!-- box4個の全体 -->
         <div class="creator__container__introduction__content">
           <ul class="creator__container__introduction__content__box">
             <!-- liは1個25%が4個並び、レスポンシブ時は1個50%が2個並び -->
-            <li class="creator__container__introduction__content__box__square">
-              <!-- aタグにpaddingを持たせるためdisplay:blockを付与 -->
-              <a href="<?php the_permalink() ?>" class="square__text">
-                <!-- 投稿する時は正方形の画像に注意 -->
-                <img class="square__text__img" alt="Syoma" src="<?php the_field('right-image'); ?>">
-                <!-- position:absoluteで中央寄せ -->
-                <span class="square__text__span"><?php the_title(); ?></span>
-              </a>
-            </li>
+            <?php $posts = get_posts('numberposts=10&category=4'); global $post; ?>
+            <?php if($posts): foreach($posts as $post): setup_postdata($post); ?>
+              <li class="creator__container__introduction__content__box__square">
+                <!-- aタグにpaddingを持たせるためdisplay:blockを付与 -->
+                <a href="<?php the_permalink() ?>" class="square__text">
+                  <!-- 投稿する時は正方形の画像に注意 -->
+                  <img class="square__text__img" alt="Syoma" src="<?php the_field('right-image'); ?>">
+                  <!-- position:absoluteで中央寄せ -->
+                  <span class="square__text__span"><?php the_title(); ?></span>
+                </a>
+              </li>
+            <?php endforeach; endif; ?>
           </ul>
         </div>
-        <?php endforeach; endif; ?>
       </div>
     </div>
   </main>

--- a/single-page-member.php
+++ b/single-page-member.php
@@ -26,13 +26,33 @@ Template Post Type: post
               <!-- 全角20文字以内 -->
               <p class="member__container__person__content__box__name__occupation"><?php the_field('occupation'); ?></p>
               <ul class="member__container__person__content__box__name__sns">
-                <!-- iタグのno-iを外すと水色に変化 -->
-                <li class="twitter sns-first-margin"><a href=<?php the_field('twitter'); ?> class="link-link"><i class="fab fa-twitter"></i></a></li>
-                <li class="instagram sns-middle-margin"><a href=<?php the_field('instagram'); ?> class="sns-link"><i class="fab fa-instagram"></i></a></li>
-                <li class="youtube sns-middle-margin"><a href=<?php the_field('youtube'); ?> class="sns-link"><i class="fab fa-youtube no-i"></i></a></li>
-                <li class="qiita sns-middle-margin"><a href=<?php the_field('qiita'); ?> class="sns-link"><i class="fas fa-search"></i></a></li>
-                <li class="github sns-middle-margin"><a href=<?php the_field('github'); ?> class="sns-link"><i class="fab fa-github"></i></a></li>
-                <li class="personal sns-last-margin"><a href=<?php the_field('personal'); ?> class="sns-link"><i class="fas fa-link"></i></a></li>
+                <?php
+                  $twitter = get_post_meta($post->ID, 'twitter', true);
+                  $instagram = get_post_meta($post->ID, 'instagram', true);
+                  $youtube = get_post_meta($post->ID, 'youtube', true);
+                  $qiita = get_post_meta($post->ID, 'qiita', true);
+                  $personal = get_post_meta($post->ID, 'personal', true);
+                  // empty関数は引数に与えた変数や配列の中身が空かどうか確認する関数
+                  // 変数の値が0あるいは空、NULLである場合はTRUEを、それ以外である場合はFALSE
+                  // 「!」は==FALSEを意味する
+                  /* if ここから */
+                  if(!empty($twitter) || !empty($instagram) || !empty($youtube) || !empty($qiita) || !empty($personal)  ){?>
+                    <?php if(!empty($twitter)):?>
+                      <li class="twitter sns-margin"><a href=<?php the_field('twitter'); ?> class="link-link"><i class="fab fa-twitter"></i></a></li>
+                    <?php endif;?>
+                    <?php if(!empty($instagram)):?>
+                      <li class="instagram sns-margin"><a href=<?php the_field('instagram'); ?> class="sns-link"><i class="fab fa-instagram"></i></a></li>
+                    <?php endif;?>
+                    <?php if(!empty($youtube)):?>
+                      <li class="youtube sns-margin"><a href=<?php the_field('youtube'); ?> class="sns-link"><i class="fab fa-youtube"></i></a></li>
+                    <?php endif;?>
+                    <?php if(!empty($qiita)):?>
+                      <li class="qiita sns-margin"><a href=<?php the_field('qiita'); ?> class="sns-link"><i class="fas fa-search"></i></a></li>
+                    <?php endif;?>
+                    <?php if(!empty($personal)):?>
+                      <li class="personal sns-margin"><a href=<?php the_field('personal'); ?> class="sns-link"><i class="fas fa-link"></i></a></li>
+                    <?php endif;?>
+                <?php } /** if ここまで */ ?>
               </ul>
             </div>
             <div class="member__container__person__content__box__sentence">

--- a/stylesheets/member.css
+++ b/stylesheets/member.css
@@ -171,14 +171,14 @@ legend {
             display: flex;
             font-size:1.5vw;
           }
-            .sns-first-margin{
-              padding-right: 0.5rem;
+            .sns-margin:first-of-type{
+              padding-left: 0;
             }
-            .sns-middle-margin{
+            .sns-margin{
               padding: 0 0.5rem;
             }
-            .sns-last-margin{
-              padding-left: 0.5rem;
+            .sns-margin:last-of-type{
+              padding-right: 0;
             }
               i{
                 color: #00A4BB;


### PR DESCRIPTION
# What
snsにリンクがあればアイコン表示する機能です。なければアイコンを消します。
※githubリンクは外部からの攻撃される可能性があるため、無しにしました。
現状はtwitter,youtube,instagram,qiita（5人目以降用）,personal（5人目以降用）です。

# Why
可読性の向上。
個人のsns活動に遷移できるようにするため。

# 備考
↓参考記事
http://wwwzz.jp/2016/10/16/3325