### PR TITLE
header ナビゲーションなど 細かい修正

### DIFF
--- a/header.php
+++ b/header.php
@@ -28,12 +28,6 @@
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.6.1/css/all.css"/>
   </head>
   <body>
-  
-
-
-    <!-- <div class="shutter">
-      <p class="text_clip">Welcom to<br/>fiber</p>
-    </div>  -->
      <header>
       <div class="logo">
         <p><a href="<?php echo home_url(); ?>"><img src="<?php echo get_template_directory_uri()?>/images/fiber_web.png" alt="main_logo" /></a></p>

--- a/index.php
+++ b/index.php
@@ -1,4 +1,5 @@
 <?php get_header()?>
+<link rel="stylesheet" href="<?php echo get_template_directory_uri()?>/stylesheets/opening.css" />
 <?php get_template_part('template/top_main');?>
 <?php get_template_part('template/top_creator');?>
 <?php get_template_part('template/top_works');?>

--- a/stylesheets/index.css
+++ b/stylesheets/index.css
@@ -1,137 +1,3 @@
-/* resetcss start */
-/*
-	TODO will need to remove settings on HTML since we can't namespace it.
-	TODO with the prefix, should I group by selector or property for weight savings?
-*/
-html {
-  color: #000;
-}
-/*
-	TODO remove settings on BODY since we can't namespace it.
-*/
-/*
-	TODO test putting a class on HEAD.
-		- Fails on FF.
-*/
-body,
-div,
-dl,
-dt,
-dd,
-ul,
-ol,
-li,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-pre,
-code,
-form,
-fieldset,
-legend,
-input,
-textarea,
-p,
-blockquote,
-th,
-td {
-  margin: 0;
-  padding: 0;
-}
-table {
-  border-collapse: collapse;
-  border-spacing: 0;
-}
-fieldset,
-img {
-  border: 0;
-}
-/*
-	TODO think about hanlding inheritence differently, maybe letting IE6 fail a bit...
-*/
-address,
-caption,
-cite,
-code,
-dfn,
-em,
-strong,
-th,
-var {
-  font-style: normal;
-  font-weight: normal;
-}
-
-ol,
-ul {
-  list-style: none;
-}
-
-caption,
-th {
-  text-align: left;
-}
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-  font-size: 100%;
-  font-weight: normal;
-}
-q:before,
-q:after {
-  content: "";
-}
-abbr,
-acronym {
-  border: 0;
-  font-variant: normal;
-}
-/* to preserve line-height and selector appearance */
-sup {
-  vertical-align: text-top;
-}
-sub {
-  vertical-align: text-bottom;
-}
-input,
-textarea,
-select {
-  font-family: inherit;
-  font-size: inherit;
-  font-weight: inherit;
-  *font-size: 100%; /*to enable resizing for IE*/
-}
-/*because legend doesn't inherit in IE */
-legend {
-  color: #000;
-}
-
-/* YUI CSS Detection Stamp */
-#yui3-css-stamp.cssreset {
-  display: none;
-}
-
-*,
-*:before,
-*:after {
-  -webkit-box-sizing: border-box;
-  box-sizing: border-box;
-}
-
-/* resetcss　end */
-/* * {
-  box-sizing: border-box;
-  width: 70%;
-  margin-left: 15%;
-  margin-right: 15%;
-} */
-
 .container_slide {
   margin: 0 auto;
   padding: 40px;
@@ -145,101 +11,6 @@ legend {
   color: #419be0;
 }
 
-/* opening start*/
-.shutter {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background-color: #fff;
-  z-index: 9999;
-  text-align: center;
-  font-size: 60px;
-  padding-top: 10%;
-  font-family: "TsukuBRdGothic-Regular", sans-serif;
-}
-.shutter::before {
-  content: "";
-  position: absolute;
-  top: 0;
-  left: 0;
-  bottom: 0;
-  margin: auto;
-  background-color: #000000;
-  width: 0;
-  height: 1px;
-}
-.shutter {
-  -webkit-animation: byeShutter 2.6s forwards;
-  animation: byeShutter 2.6s forwards;
-}
-.shutter::before {
-  -webkit-animation: shutterOpen 2.6s forwards;
-  animation: shutterOpen 2.6s forwards;
-}
-.container {
-  -webkit-animation: contentScale 2.6s forwards;
-  animation: contentScale 2.6s forwards;
-}
-@keyframes byeShutter {
-  70% {
-    opacity: 1;
-  }
-  100% {
-    opacity: 0;
-    display: none;
-    z-index: -1;
-  }
-}
-
-@keyframes shutterOpen {
-  0% {
-    width: 0;
-    height: 1px;
-  }
-  50% {
-    width: 100%;
-    height: 1px;
-  }
-  90% {
-    width: 100%;
-    height: 100%;
-  }
-  100% {
-    width: 100%;
-    height: 100%;
-  }
-}
-
-@keyframes contentScale {
-  70% {
-    -webkit-transform: perspective(800px) scale(0.9) rotateX(15deg);
-    transform: perspective(800px) scale(0.9) rotateX(15deg);
-  }
-  100% {
-    -webkit-transform: perspective(800px) scale(1) rotateX(0);
-    transform: perspective(800px) scale(1) rotateX(0);
-  }
-}
-p.text_clip {
-  animation: flash 1s linear infinite;
-}
-@keyframes flash {
-  0% {
-    opacity: 1;
-  }
-
-  50% {
-    opacity: 0;
-  }
-
-  100% {
-    opacity: 1;
-  }
-}
-
-/* opening end*/
 /* header css start */
 header {
   display: flex;
@@ -309,7 +80,7 @@ header {
   left: 0;
   z-index: 9999; /*最前面に*/
   width: 90%; /*右側に隙間を作る（閉じるカバーを表示）*/
-  max-width: 40%; /*最大幅（調整してください）*/
+  max-width: 50%; /*最大幅（調整してください）*/
   height: 100%;
   background: #fff; /*背景色*/
   transition: 0.3s ease-in-out; /*滑らかに表示*/
@@ -347,7 +118,7 @@ header .logo {
   position: fixed;
   /*上端との距離*/
   right: 5%;
-  top: 3%;
+  top: 8%;
   /*高さ画面いっぱい*/
   /*滑らかスクロール*/
   -webkit-overflow-scrolling: touch;
@@ -356,12 +127,14 @@ header .logo {
   width: 80px;
   height: 80px;
   margin: 0 auto;
-  background: url(rose_img.jpg) no-repeat center center;
   background-size: contain;
+}
+audio {
+  width: 100%;
 }
 nav {
   display: block;
-  margin: 0 auto;
+  margin: 8% auto;
 }
 header ul {
 }
@@ -565,7 +338,7 @@ img {
   }
   #nav-drawer {
     right: 7%;
-    top: 2%;
+    top: 18%;
   }
   .blog-articles01-module--row {
     display: contents;
@@ -659,7 +432,7 @@ dd {
 .article-item img {
   /* 画像は親要素に対して100%にする */
   width: 100%;
-  height: 100%;
+  height: 200px;
 }
 
 .article-title {

--- a/stylesheets/opening.css
+++ b/stylesheets/opening.css
@@ -1,0 +1,95 @@
+/* opening start*/
+.shutter {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #fff;
+  z-index: 9999;
+  text-align: center;
+  font-size: 60px;
+  padding-top: 10%;
+  font-family: "TsukuBRdGothic-Regular", sans-serif;
+}
+.shutter::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  margin: auto;
+  background-color: #000000;
+  width: 0;
+  height: 1px;
+}
+.shutter {
+  -webkit-animation: byeShutter 2.6s forwards;
+  animation: byeShutter 2.6s forwards;
+}
+.shutter::before {
+  -webkit-animation: shutterOpen 2.6s forwards;
+  animation: shutterOpen 2.6s forwards;
+}
+.container {
+  -webkit-animation: contentScale 2.6s forwards;
+  animation: contentScale 2.6s forwards;
+}
+@keyframes byeShutter {
+  70% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+    display: none;
+    z-index: -1;
+  }
+}
+
+@keyframes shutterOpen {
+  0% {
+    width: 0;
+    height: 1px;
+  }
+  50% {
+    width: 100%;
+    height: 1px;
+  }
+  90% {
+    width: 100%;
+    height: 100%;
+  }
+  100% {
+    width: 100%;
+    height: 100%;
+  }
+}
+
+@keyframes contentScale {
+  70% {
+    -webkit-transform: perspective(800px) scale(0.9) rotateX(15deg);
+    transform: perspective(800px) scale(0.9) rotateX(15deg);
+  }
+  100% {
+    -webkit-transform: perspective(800px) scale(1) rotateX(0);
+    transform: perspective(800px) scale(1) rotateX(0);
+  }
+}
+p.text_clip {
+  animation: flash 1s linear infinite;
+}
+@keyframes flash {
+  0% {
+    opacity: 1;
+  }
+
+  50% {
+    opacity: 0;
+  }
+
+  100% {
+    opacity: 1;
+  }
+}
+
+/* opening end*/

--- a/template/top_blog.php
+++ b/template/top_blog.php
@@ -13,7 +13,11 @@
         <article class="article-item box">
           <a href="<?php the_permalink(); ?>">
             <div class="article-inside">
+            <?php if(has_post_thumbnail()): ?>
               <?php the_post_thumbnail(array(350), array('class' => 'thumb')); ?>
+            <?php else: ?>
+              <img src="<?php echo get_template_directory_uri()?>/images/fiber_web.png">
+            <?php endif; ?>
               <h3 class="article-title">
               <?php echo mb_substr(the_title(), 0, 15, 'UTF-8'); ?>	
               </h3>

--- a/template/top_main.php
+++ b/template/top_main.php
@@ -1,11 +1,6 @@
-<!-- slick.jsのテンプレート用 -->
-<!-- <ul class="your-class">
-  <li><a href="#"><img src="https://125naroom.com/demo/img/itukanokotonokoto01.jpg" alt="sample"></a></li>
-  <li><a href="#"><img src="https://125naroom.com/demo/img/itukanokotonokoto02.jpg" alt="sample"></a></li>
-  <li><a href="#"><img src="https://125naroom.com/demo/img/itukanokotonokoto03.jpg" alt="sample"></a></li>
-  <li><a href="#"><img src="https://125naroom.com/demo/img/itukanokotonokoto04.jpg" alt="sample"></a></li>
-</ul> -->
-
+<div class="shutter">
+  <p class="text_clip">Welcom to<br/>fiber</p>
+</div> 
 <!-- slick.jsではないスライド -->
 <div class="wrap">
   <ul id="slide_wrap">
@@ -22,8 +17,7 @@
 </div>
 
 <section class="t-fiber-about">
-<div class="t-fiber-about__title">
-  <p></p>
+  <div class="t-fiber-about__title">
 </div>
 <div class="t-fiber-about__content">
     <p class="element js-fadein">fiberは、デザイナーやエンジニア・マーケター等、</p>


### PR DESCRIPTION
#WHY
ビュー崩れや無駄なアニメーションの修正

#WHAT
openingのアニメーションをtopページだけで出るようにした。
topのブログ画像の適正サイズ化
ブログ投稿でアイキャッチ画像が設定されていなければfiberの画像を出力
<img width="571" alt="スクリーンショット 2020-08-02 23 55 13" src="https://user-images.githubusercontent.com/54714018/89125973-14ebff80-d51d-11ea-8a41-81b1337d7422.png">
<img width="1440" alt="スクリーンショット 2020-08-03 0 00 32" src="https://user-images.githubusercontent.com/54714018/89125977-19b0b380-d51d-11ea-9b8e-3cf47f072c04.png">
<img width="1437" alt="スクリーンショット 2020-08-03 0 00 46" src="https://user-images.githubusercontent.com/54714018/89125979-1c130d80-d51d-11ea-9b9b-ca27b8471aff.png">
