### PR TITLE
works調整

### DIFF
--- a/slick/slick.css
+++ b/slick/slick.css
@@ -89,6 +89,10 @@
 .slick-slide img
 {
     display: block;
+    /* height: 100vw;
+    max-height: 400px;
+    min-height: 350px;
+    width: 80%; */
 }
 .slick-slide.slick-loading img
 {

--- a/stylesheets/works.css
+++ b/stylesheets/works.css
@@ -89,6 +89,7 @@ a {
 }
 .wk-list-item-module {
   position: relative;
+  margin-bottom: 50px;
 }
 .wk-list-item-module__figure {
   height: 600px;


### PR DESCRIPTION
# What
実績一覧view調整。
works.cssの『wk-list-module__item』にmargin-bottomを追加し、被りを解消。

![screencapture-test2-local-works-2020-08-10-11_19_22](https://user-images.githubusercontent.com/55389524/89747818-6129d780-dafb-11ea-9e6c-10df74e75f5e.png)
