### PR TITLE
skill unlink

### DIFF
--- a/single-page-member.php
+++ b/single-page-member.php
@@ -63,7 +63,16 @@ Template Post Type: post
               <h3 class="member__container__person__content__box__skill__title">スキルセット</h3>
               <!-- スキルセットは15個以内 -->
               <ul class="member__container__person__content__box__skill__element">
-                <?php the_tags('<li class="skill">', '</li><li class="skill">', '</li>') ?>
+                <?php
+                  $posttags = get_the_tags();
+                    if ( $posttags ) {
+                      foreach ( $posttags as $tag ) {
+                        echo '<li class="skill">'.$tag->name.'</li>';
+                      }
+                    }
+                  ?>
+                  <!-- スキルをリンク有りにする場合は↓ -->
+                  <!-- php the_tags('<li class="skill">', '</li><li class="skill">', '</li>')  -->
               </ul>
             </div>
           </div>


### PR DESCRIPTION
# What
member詳細ページにて、skillリンクの無効化。

# Why
クリエイターが少ないのでskillで絞るメリットがないため。人数が増えた時に絞れるようにする。